### PR TITLE
Stricter identification of EAC3 tracks

### DIFF
--- a/eac3toac3.sh
+++ b/eac3toac3.sh
@@ -10,7 +10,7 @@ IFILE=$(basename "$MKV_INPUT")
 IFILE="${IFILE%.*}"
 
 # get E-AC3 audio track ID from MKV container
-LINE=$(LANG=C mkvinfo "${MKV_INPUT}" | grep "Track type" | grep -n "audio" | cut -d":" -f1)
+LINE=$(LANG=C mkvinfo "${MKV_INPUT}" | grep "Codec ID" | grep -n "A_EAC3" | cut -d":" -f1)
 AUDIO_ID=$(( $LINE - 1 ))
 
 # extract E-AC3 audio track from MKV container


### PR DESCRIPTION
With this edit the script only processes files that actually contain an EAC3 track. Also it makes sure that when there are multiple audio tracks (eg. DTS and EAC3) it finds the right one.